### PR TITLE
send new invoice email to customer (if configured)

### DIFF
--- a/app/code/community/Wirecard/CheckoutPage/controllers/ProcessingController.php
+++ b/app/code/community/Wirecard/CheckoutPage/controllers/ProcessingController.php
@@ -349,6 +349,8 @@ class Wirecard_CheckoutPage_ProcessingController extends Mage_Core_Controller_Fr
                         ->addObject($invoice)
                         ->addObject($invoice->getOrder())
                         ->save();
+
+                    $invoice->sendEmail();
                 }
                 // send new order email to customer
                 $order->sendNewOrderEmail();


### PR DESCRIPTION
fixes https://github.com/wirecard/magento-wcp/issues/35

It is save to directly call `sendEmail` on the invoice model here because magento's implementation of the method will then check if sending an email is enabled in the config settings for the corresponding store view.