### PR TITLE
update API endpoint urls to qenta instead of wirecard

### DIFF
--- a/app/code/local/QentaCEE/QMore/Config/client.config.php
+++ b/app/code/local/QentaCEE/QMore/Config/client.config.php
@@ -31,9 +31,9 @@
  */
 
 return Array(
-    'DATA_STORAGE_URL' => 'https://checkout.wirecard.com/seamless/dataStorage',
-    'FRONTEND_URL'     => 'https://checkout.wirecard.com/seamless/frontend',
-    'BACKEND_URL'      => 'https://checkout.wirecard.com/seamless/backend',
+    'DATA_STORAGE_URL' => 'https://api.qenta.com/seamless/dataStorage',
+    'FRONTEND_URL'     => 'https://api.qenta.com/seamless/frontend',
+    'BACKEND_URL'      => 'https://api.qenta.com/seamless/backend',
     'MODULE_NAME'      => 'QentaCEE_QMore',
     'MODULE_VERSION'   => '3.3.0',
     'DEPENDENCIES'     => array(),

--- a/app/code/local/QentaCEE/QPay/Config/client.config.php
+++ b/app/code/local/QentaCEE/QPay/Config/client.config.php
@@ -32,8 +32,8 @@
 
 
 return Array(
-    'FRONTEND_URL'   => 'https://checkout.wirecard.com/page/init-server.php',
-    'TOOLKIT_URL'    => 'https://checkout.wirecard.com/page/toolkit.php',
+    'FRONTEND_URL'   => 'https://api.qenta.com/page/init-server.php',
+    'TOOLKIT_URL'    => 'https://api.qenta.com/page/toolkit.php',
     'MODULE_NAME'    => 'QentaCEE_QPay',
     'MODULE_VERSION' => '3.3.0',
     'DEPENDENCIES'   => Array(),


### PR DESCRIPTION
update API endpoint URLs as [suggested by the official guidelines](https://guides.qenta.com/shop_url_adaptions/)